### PR TITLE
Fix manually entered url's 404ing

### DIFF
--- a/gvnmcg/src/App.js
+++ b/gvnmcg/src/App.js
@@ -1,11 +1,5 @@
 import React from "react";
-import {
-  BrowserRouter as Router,
-  Switch,
-  Route,
-  Link,
-  HashRouter,
-} from "react-router-dom";
+import { Switch, Route, Link, HashRouter } from "react-router-dom";
 import CBTApp from "./CBTApp";
 
 import MDComponent from "./components/MDComponent";

--- a/gvnmcg/src/App.js
+++ b/gvnmcg/src/App.js
@@ -1,5 +1,11 @@
 import React from "react";
-import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  Link,
+  HashRouter,
+} from "react-router-dom";
 import CBTApp from "./CBTApp";
 
 import MDComponent from "./components/MDComponent";
@@ -13,7 +19,7 @@ const App = () => (
       <h1>Gavin McGuire</h1>
     </div>
 
-    <Router>
+    <HashRouter>
       <div className="navigator">
         <Link to="/"> Home </Link>
         <Link to="/resume"> Resume </Link>
@@ -36,7 +42,7 @@ const App = () => (
           <Route path="/styles" component={<p>In progress</p>} />
         </Switch>
       </div>
-    </Router>
+    </HashRouter>
   </div>
 );
 

--- a/gvnmcg/src/App.js
+++ b/gvnmcg/src/App.js
@@ -30,21 +30,10 @@ const App = () => (
 
       <div className="content">
         <Switch>
-          <Route path="/resume">
-            <MDComponent />
-          </Route>
-
-          <Route path="/playlists">
-            <Playlists />
-          </Route>
-
-          <Route path="/cbt">
-            <CBTApp />
-          </Route>
-
-          <Route path="/styles">
-            <p>In progress</p>
-          </Route>
+          <Route path="/resume" component={MDComponent} />
+          <Route path="/playlists" component={Playlists} />
+          <Route path="/cbt" component={CBTApp} />
+          <Route path="/styles" component={<p>In progress</p>} />
         </Switch>
       </div>
     </Router>


### PR DESCRIPTION
Due to the structure of this app we have to use a `HashRouter` instead of a normal `BrowserRouter`. Converted to using react-router `component` prop instead of rendering the child of the route.

Testing:

- Open https://5f794d9d35aa940008473749--jolly-hugle-dc305d.netlify.app/#/ and manually enter a URL besides `/`. It should no longer 404. 
-  Open https://5f794d9d35aa940008473749--jolly-hugle-dc305d.netlify.app/#/ and navigate to any of the other pages and refresh. It should no longer 404.